### PR TITLE
 Add ability to search by `--ray-id` 

### DIFF
--- a/cmd/logshare-cli/main.go
+++ b/cmd/logshare-cli/main.go
@@ -96,7 +96,6 @@ func run(conf *config) func(c *cli.Context) error {
 			&logshare.Options{
 				Fields:          conf.fields,
 				Dest:            outputWriter,
-				ByReceived:      true,
 				Sample:          conf.sample,
 				TimestampFormat: conf.timestampFormat,
 			})
@@ -172,7 +171,6 @@ type config struct {
 }
 
 func (conf *config) Validate() error {
-
 	if conf.apiKey == "" || conf.apiEmail == "" {
 		return errors.New("Must provide both api-key and api-email")
 	}

--- a/cmd/logshare-cli/main.go
+++ b/cmd/logshare-cli/main.go
@@ -108,7 +108,13 @@ func run(conf *config) func(c *cli.Context) error {
 		// endpoint.
 		var meta *logshare.Meta
 
-		if conf.listFields {
+		if conf.rayID != "" {
+			meta, err = client.GetFromRayID(conf.zoneID, conf.rayID)
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch via ray ID")
+			}
+
+		} else if conf.listFields {
 			meta, err = client.FetchFieldNames(conf.zoneID)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch field names")
@@ -143,6 +149,7 @@ func parseFlags(conf *config, c *cli.Context) error {
 	conf.listFields = c.Bool("list-fields")
 	conf.googleStorageBucket = c.String("google-storage-bucket")
 	conf.googleProjectID = c.String("google-project-id")
+	conf.rayID = c.String("ray-id")
 
 	return conf.Validate()
 }
@@ -161,6 +168,7 @@ type config struct {
 	listFields          bool
 	googleStorageBucket string
 	googleProjectID     string
+	rayID               string
 }
 
 func (conf *config) Validate() error {

--- a/logshare.go
+++ b/logshare.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -17,14 +18,11 @@ import (
 
 const (
 	apiURL     = "https://api.cloudflare.com/client/v4"
-	byRequest  = "requests"
-	byReceived = "received"
-)
-
-const (
-	unix     = "unix"
-	unixNano = "unixnano"
-	rfc3339  = "rfc3339"
+	unix       = "unix"
+	unixNano   = "unixnano"
+	rfc3339    = "rfc3339"
+	byRecieved = "received"
+	byRayID    = "rayids"
 )
 
 // Client holds the current API credentials & HTTP client configuration. Client
@@ -114,27 +112,34 @@ func New(apiKey string, apiEmail string, options *Options) (*Client, error) {
 }
 
 func (c *Client) buildURL(zoneID string, params url.Values) (*url.URL, error) {
-	endpoint := byReceived
-	if !c.byReceived {
-		endpoint = byRequest
+	endpointType := byRecieved
+
+	rayID := params.Get("rayid")
+	if rayID != "" {
+		endpointType = byRayID
+		params.Del("rayid")
 	}
 
 	u, err := url.Parse(
 		fmt.Sprintf("%s/zones/%s/logs/%s",
 			c.endpoint,
 			zoneID,
-			endpoint,
+			endpointType,
 		),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.byReceived && len(c.fields) >= 1 {
+	if endpointType == byRayID {
+		u.Path = path.Join(u.Path, rayID)
+	}
+
+	if len(c.fields) >= 1 {
 		params.Set("fields", strings.Join(c.fields, ","))
 	}
 
-	if c.sample != 0.0 {
+	if endpointType != byRayID && c.sample != 0.0 {
 		params.Set("sample", strconv.FormatFloat(c.sample, 'f', 1, 64))
 	}
 
@@ -143,7 +148,21 @@ func (c *Client) buildURL(zoneID string, params url.Values) (*url.URL, error) {
 	}
 
 	u.RawQuery = params.Encode()
+
 	return u, nil
+}
+
+// GetFromRayID fetches a log entry based on a provided Ray ID value.
+func (c *Client) GetFromRayID(zoneID string, rayID string) (*Meta, error) {
+	params := url.Values{}
+	params.Set("rayid", rayID)
+
+	url, err := c.buildURL(zoneID, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.request(url)
 }
 
 // GetFromTimestamp fetches logs between the start and end timestamps provided,
@@ -172,9 +191,10 @@ func (c *Client) GetFromTimestamp(zoneID string, start int64, end int64, count i
 func (c *Client) FetchFieldNames(zoneID string) (*Meta, error) {
 	u, err := url.Parse(
 		fmt.Sprintf(
-			"%s/zones/%s/logs/received/fields",
+			"%s/zones/%s/logs/%s/fields",
 			c.endpoint,
 			zoneID,
+			byRecieved,
 		),
 	)
 	if err != nil {

--- a/logshare.go
+++ b/logshare.go
@@ -31,7 +31,6 @@ type Client struct {
 	endpoint        string
 	apiKey          string
 	apiEmail        string
-	byReceived      bool
 	sample          float64
 	timestampFormat string
 	fields          []string
@@ -48,8 +47,6 @@ type Options struct {
 	Headers http.Header
 	// Destination to stream logs to.
 	Dest io.Writer
-	// Fetch logs by the processing/received timestamp
-	ByReceived bool
 	// Which timestamp format to use: one of "unix", "unixnano", "rfc3339"
 	TimestampFormat string
 	// Whether to only retrieve a sample of logs (0.1 to 0.9)
@@ -79,12 +76,6 @@ func New(apiKey string, apiEmail string, options *Options) (*Client, error) {
 		return nil, errors.New("apiEmail cannot be empty")
 	}
 
-	// Default to the received endpoint.
-	var byReceived = true
-	if options != nil {
-		byReceived = options.ByReceived
-	}
-
 	client := &Client{
 		apiKey:     apiKey,
 		apiEmail:   apiEmail,
@@ -92,7 +83,6 @@ func New(apiKey string, apiEmail string, options *Options) (*Client, error) {
 		httpClient: http.DefaultClient,
 		dest:       os.Stdout,
 		headers:    make(http.Header),
-		byReceived: byReceived,
 	}
 
 	if options != nil {


### PR DESCRIPTION
This functionality used to be available via another legacy endpoint
however it was [deprecated](https://github.com/cloudflare/logshare/pull/14) and removed in favour of a combination of
the `/received` endpoint and `jq` magic due to some ongoing performance
issues on the Cloudflare end.

Thankfully, the ability to search by Ray ID has returned on a new
[dedicated endpoint](https://api.cloudflare.com/#logs-recieved-logs-rayids
) that hangs off the back of the `/received` route.

In order to use this, I've updated the client and the CLI to accept the
`--ray-id` parameter and build out the correct request.

Brings in patch from cloudflare/logshare#30